### PR TITLE
chore(netlify): set client timeout to 10 minutes

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -141,4 +141,4 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 5
+        timeout-minutes: 10


### PR DESCRIPTION
Increase the timeout from 5 to 10 minutes as the site
deploy sometimes takes more than 5 minutes.
10 minutes is short enough to not be an issue in term of reactivity
And it is not that large so we will be able to detect any deployment time increase if it occurs,