### PR TITLE
chore: update after gh-pages removal

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -38,13 +38,6 @@ content:
 ui:
   bundle:
     url: ./resources/antora-ui-bundle.zip
-  # Ensure we have a .nojekyll file to avoid Jekyll generation when using github-pages
-  # https://docs.antora.org/antora/2.3/publish-to-github-pages/#use-the-supplemental-ui
-  supplemental_files:
-    - path: ui.yml
-      contents: |
-        static_files: [ .nojekyll ]
-    - path: .nojekyll
 
 asciidoc:
   extensions:

--- a/docs/migrate-from-old-documentation-site/migration-steps-put-the-site-live.adoc
+++ b/docs/migrate-from-old-documentation-site/migration-steps-put-the-site-live.adoc
@@ -109,13 +109,32 @@ Strategy:
 update the antora playbook
 
 * site.url: https://documentation.bonitasoft.com
-* update the gh-pages settings and set the https://docs.github.com/articles/using-a-custom-domain-with-github-pages/[custom domain]
 
-WARNING: the gh-pages custom settings could be done earlier if this has no impact on existing site. *TO BE INVESTIGATED.*
+
+=== Search
+
+Update the DocSearch configuration: use the new domain
+
+
+=== Hosting
+
+* add a new Netlify Custom Domain and make it use the final https://docs.netlify.com/domains-https/custom-domains/[custom domain]
+
+[WARNING]
+====
+to be investigated
+
+we probably need to keep the preview domain for docsearch:
+
+* until the crawler has been run using the new url, the preview one must be available
+* once the new domain has crawled, the preview domain can be removed from netlify and from the DNS
+====
+
+
 
 === infra
 
-* update CDN: warn propagation can take time, decide how to do the switch
+* update DNS: warn propagation can take time, decide how to do the switch
 * disable webhooks configured on doc content repositories that target the internal Bonitasoft CI
   * BICI doc webhooks have already been disabled on 2020-11-26 as there was no update on 1.x branch and the new master branch
 made the builds fail


### PR DESCRIPTION
Remove the .nojekyll file generation.
This was required by the github pages hosting that we have just removed, so no
need to generate this file anymore.

Remove reference to gh-pages from the documentation.