### PR TITLE
chore: update url redirect

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -23,6 +23,7 @@ on:
       - 'resources/*'
       - 'antora-playbook.yml'
       - '.github/workflows/generate-documentation.yml'
+      - 'netlify.toml'
 jobs:
   generate_doc:
     runs-on: ubuntu-20.04

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,8 @@
 ########################################
 [[redirects]]
   from = "/bonita/latest/*"
-# TODO if we want proxy/rewrite instead, add status = 200 (https://docs.netlify.com/routing/redirects/rewrites-proxies/)
   to = "/bonita/2021.1/:splat"
+  status = 200
 
 [[redirects]]
   from = "/bonita/"
@@ -15,14 +15,20 @@
   from = "/bonita/7.12/*"
   to = "/bonita/2021.1/:splat"
 
+# Bonita Javadoc redirect
+[[redirects]]
+  from = "/javadoc/api/*"
+  to = "https://javadoc.bonitasoft.com/api/:splat"
+
+# TODO: Add redirect to Groovydoc
 
 ########################################
 # BCD redirects
 ########################################
 [[redirects]]
 from = "/bcd/latest/*"
-# TODO if we want proxy/rewrite instead, add status = 200 (https://docs.netlify.com/routing/redirects/rewrites-proxies/)
 to = "/bcd/3.4/:splat"
+status = 200
 
 [[redirects]]
 from = "/bcd/"
@@ -61,27 +67,27 @@ to = "/bcd/latest/:splat"
 ########################################
 [[redirects]]
 from = "/bici/"
-to = "/bici/latest/"
+to = "/labs/latest/bici/"
 
 [[redirects]]
 from = "/bici/1.0/*"
-to = "/bici/latest/:splat"
+to = "/labs/latest/bici/:splat"
 
 [[redirects]]
 from = "/bici/1.1/*"
-to = "/bici/latest/:splat"
+to = "/labs/latest/bici/:splat"
 
 [[redirects]]
 from = "/bici/1.2/*"
-to = "/bici/latest/:splat"
+to = "/labs/latest/bici/:splat"
 
 [[redirects]]
 from = "/bici/1.3/*"
-to = "/bici/latest/:splat"
+to = "/labs/latest/bici/:splat"
 
 [[redirects]]
 from = "/ici/:version/*"
-to = "/bici/latest/:splat"
+to = "/labs/latest/bici/:splat"
 
 
 
@@ -98,5 +104,10 @@ to = "/cloud/latest/"
 [[redirects]]
 from = "/6.x-7.2/*"
 to = "https://documentation-legacy.bonitasoft.com/6.x-7.2/:splat"
+
+# Redirect 5x url to archive version documentation
+[[redirects]]
+from = "/5x/*"
+to = "/bonita/0/"
 
 


### PR DESCRIPTION
* latest redirect for bonita and bcd as rewrite (proxy) instead of redicrect
* Bici redirect to labs/bici/
* javadoc/api to https://javadoc.bonitasoft.com/api/:splat